### PR TITLE
Include variables highlight in host file

### DIFF
--- a/Ansible.YAML-tmLanguage
+++ b/Ansible.YAML-tmLanguage
@@ -33,6 +33,6 @@ patterns:
       match: .
 
 - name: string.quoted.double.ansible
-  match: ^(\[[0-9a-zA-Z_-]+(((\:)children)*)\])
+  match: ^(\[[0-9a-zA-Z_-]+(((\:)children|vars)*)\])
   captures:
     '2': {name: variable.parameter.ansible}


### PR DESCRIPTION
Just a minor edit to include :vars in the Ansible hosts file definition.
